### PR TITLE
check for null of sliderref prior to resize

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -100,8 +100,10 @@ export default class Slider extends Component {
 
 
   onWindowResize = () => {
-    this._sliderWidth = this._sliderRef.clientWidth;
-    this.forceUpdate();
+    if(this._sliderRef){
+      this._sliderWidth = this._sliderRef.clientWidth;
+      this.forceUpdate();
+    }
   };
 
 


### PR DESCRIPTION
Was getting a number of null exceptions when resizing.  Might be a little hacky, but i put in a null check before resetting slider width